### PR TITLE
Add icon library lucide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "gazeplottersveltekit",
 			"version": "0.0.1",
+			"dependencies": {
+				"lucide-svelte": "^0.306.0"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/adapter-static": "^3.0.1",
@@ -45,7 +48,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -175,7 +177,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -189,7 +190,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -198,7 +198,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -206,14 +205,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.20",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
 			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -411,8 +408,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-			"dev": true
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -747,7 +743,6 @@
 			"version": "8.11.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
 			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -836,7 +831,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -863,7 +857,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
 			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -1008,7 +1001,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
 			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@types/estree": "^1.0.1",
@@ -1068,7 +1060,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"dependencies": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -1143,7 +1134,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1454,7 +1444,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -1894,7 +1883,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
 			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -2018,8 +2006,7 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -2072,11 +2059,18 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/lucide-svelte": {
+			"version": "0.306.0",
+			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.306.0.tgz",
+			"integrity": "sha512-Jd2KK7FHsx60wRwanL750JilaXyR4Tbwh7RmqcG3sda/SG7hPWWbMqqpAz4d97+D1Qj0FMzTmCCNjSPZykSTJA==",
+			"peerDependencies": {
+				"svelte": ">=3 <5"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
 			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
@@ -2087,8 +2081,7 @@
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
@@ -2481,7 +2474,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -3020,7 +3012,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3113,7 +3104,6 @@
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
 			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   },
   "svelte": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "lucide-svelte": "^0.306.0"
+  }
 }

--- a/src/lib/components/General/GeneralButton/GeneralButtonMenu.svelte
+++ b/src/lib/components/General/GeneralButton/GeneralButtonMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MinorButton from './GeneralButtonMinor.svelte'
   import { onMount, onDestroy } from 'svelte'
+  import MoreVertical from 'lucide-svelte/icons/more-vertical'
 
   interface ActionItem {
     label: string
@@ -45,11 +46,7 @@
 
 <div class="wrap" bind:this={menuElement}>
   <MinorButton on:click={handleClick}>
-    <span class:isOpen>
-      <span></span>
-      <span></span>
-      <span></span>
-    </span>
+    <MoreVertical size={'1em'} />
   </MinorButton>
   {#if isOpen}
     <ul class="menu">
@@ -65,6 +62,7 @@
 <style>
   .wrap {
     position: relative;
+    display: flex;
   }
   .menu {
     position: absolute;
@@ -95,18 +93,5 @@
   }
   .menu button:hover {
     background: #f5f5f5;
-  }
-  span {
-    display: inline-block;
-    justify-content: center;
-    align-items: center;
-  }
-  span > span {
-    display: block;
-    width: 3px;
-    height: 3px;
-    background-color: currentColor;
-    border-radius: 50%;
-    margin: 2px;
   }
 </style>

--- a/src/lib/components/General/GeneralButton/GeneralButtonMenu.svelte
+++ b/src/lib/components/General/GeneralButton/GeneralButtonMenu.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import MinorButton from './GeneralButtonMinor.svelte'
-  import { onMount, onDestroy } from 'svelte'
+  import { onMount, onDestroy, type ComponentType } from 'svelte'
   import MoreVertical from 'lucide-svelte/icons/more-vertical'
 
   interface ActionItem {
+    icon: ComponentType
     label: string
     action: () => void
   }
@@ -14,7 +15,7 @@
     isOpen = !isOpen
   }
 
-  let window: Window
+  let window: Window | null
 
   let menuElement: HTMLDivElement
 
@@ -33,8 +34,8 @@
 
   onMount(() => {
     window = document.defaultView
-    window.addEventListener('click', handleOutsideClick)
-    window.addEventListener('keydown', handleKeydown)
+    window?.addEventListener('click', handleOutsideClick)
+    window?.addEventListener('keydown', handleKeydown)
   })
 
   onDestroy(() => {
@@ -52,7 +53,10 @@
     <ul class="menu">
       {#each items as item}
         <li>
-          <button on:click={item.action}>{item.label}</button>
+          <button on:click={item.action}>
+            <svelte:component this={item.icon} size={'1em'} />
+            {item.label}
+          </button>
         </li>
       {/each}
     </ul>
@@ -77,7 +81,7 @@
   .menu,
   li {
     list-style: none;
-    width: 150px;
+    min-width: 175px;
     margin: 0;
     padding: 0;
   }
@@ -90,6 +94,9 @@
     cursor: pointer;
     width: 100%;
     text-align: left;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5em;
   }
   .menu button:hover {
     background: #f5f5f5;

--- a/src/lib/components/General/GeneralButton/GeneralButtonMinor.svelte
+++ b/src/lib/components/General/GeneralButton/GeneralButtonMinor.svelte
@@ -3,19 +3,13 @@
   const dispatch = createEventDispatcher()
 
   export let isDisabled = false
-  export let marginTop =
-    '7px' /* For usage with compact selects in headers of plots */
 
   const handleClick = () => {
     dispatch('click')
   }
 </script>
 
-<button
-  disabled={isDisabled}
-  on:click={handleClick}
-  style="margin-top: {marginTop}"
->
+<button disabled={isDisabled} on:click={handleClick}>
   <slot />
 </button>
 
@@ -25,15 +19,12 @@
     border: 1px solid rgba(0, 0, 0, 0.23);
     border-radius: 4px;
     color: rgba(0, 0, 0, 0.87);
-    padding: 0;
+    padding: 0.25em 0.5em;
     text-align: center;
     text-decoration: none;
-    display: inline-flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: center;
     font-size: 16px;
-    width: 34px;
-    height: 34px;
     cursor: pointer;
   }
   button:hover {

--- a/src/lib/components/General/GeneralSelect/GeneralSelectBase.svelte
+++ b/src/lib/components/General/GeneralSelect/GeneralSelectBase.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  export let options: Array<{ value: string; label: string }>
-  export let label: string
-  export let value = ''
-  const name = label.toLowerCase().replace(/ /g, '-')
+  import ChevronDown from "lucide-svelte/icons/chevron-down";
+
+  export let options: Array<{ value: string; label: string }>;
+  export let label: string;
+  export let value: string = "";
+  const name = label.toLowerCase().replace(/ /g, "-");
   const handleChange = (e: Event) => {
-    const target = e.target as HTMLSelectElement
-    value = target.value
-  }
+    const target = e.target as HTMLSelectElement;
+    value = target.value;
+  };
 </script>
 
 <div class="wrap">
@@ -19,6 +21,7 @@
         >
       {/each}
     </select>
+    <ChevronDown />
   </div>
 </div>
 
@@ -32,8 +35,7 @@
   select {
     font-weight: 400;
     color: rgba(0, 0, 0, 0.87);
-    border-radius: 4px;
-    border: 1px solid rgba(0, 0, 0, 0.23);
+    border: none;
     background: none;
     transition: border-color 0.2s ease-in-out;
     font-size: 14px;
@@ -47,21 +49,12 @@
   }
 
   .select-wrap {
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.23);
     position: relative;
     width: 170px;
-  }
-
-  .select-wrap:after {
-    content: '⌄';
-    position: absolute;
-    top: 0;
-    right: 17px;
-    color: rgba(0, 0, 0, 0.54);
-    width: 1px;
-    height: 100%;
-    box-sizing: border-box;
-    padding-top: 1px;
-    pointer-events: none;
+    display: flex;
+    align-items: center;
   }
   select:focus {
     outline: none;

--- a/src/lib/components/General/GeneralSelect/GeneralSelectCompact.svelte
+++ b/src/lib/components/General/GeneralSelect/GeneralSelectCompact.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ChevronDown from 'lucide-svelte/icons/chevron-down'
   export let options: Array<{ value: string; label: string }>
   export let label: string
   export let value: string = options[0].value
@@ -9,19 +10,22 @@
   }
 </script>
 
-<div>
+<div class="select-wrapper">
   <label for={name}>{label}</label>
-  <select {name} id="GP-{name}" on:change={handleChange}>
-    {#each options as option}
-      <option value={option.value} selected={option.value === value}
-        >{option.label}</option
-      >
-    {/each}
-  </select>
+  <div class="option-wrapper">
+    <select {name} id="GP-{name}" on:change={handleChange}>
+      {#each options as option}
+        <option value={option.value} selected={option.value === value}
+          >{option.label}</option
+        >
+      {/each}
+    </select>
+    <ChevronDown strokeWidth={1} />
+  </div>
 </div>
 
 <style>
-  div {
+  .select-wrapper {
     display: flex;
     flex-direction: column;
     position: relative;
@@ -37,14 +41,21 @@
     background: var(--c-darkgrey);
     padding-inline: 4px;
     left: 10px;
+    top: -1em;
+  }
+  .option-wrapper {
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.23);
+    padding: 0.25em 0.5em;
   }
   select {
     font-weight: 400;
     line-height: 1.5rem;
     letter-spacing: 0.00938em;
     color: rgba(0, 0, 0, 0.87);
-    border-radius: 4px;
-    border: 1px solid rgba(0, 0, 0, 0.23);
+    border: none;
     background-color: var(--c-darkgrey);
     transition: border-color 0.2s ease-in-out;
     font-size: 14px;
@@ -53,22 +64,6 @@
     -moz-appearance: none;
     appearance: none;
     cursor: pointer;
-    padding: 5px 23px 3px 13px;
-    margin: 7px 0 0;
-    height: 34px;
-  }
-
-  div:after {
-    content: '⌄';
-    position: absolute;
-    top: 0;
-    right: 17px;
-    color: rgba(0, 0, 0, 0.54);
-    width: 1px;
-    height: 100%;
-    box-sizing: border-box;
-    padding-top: 8px;
-    pointer-events: none;
   }
 
   select:focus {

--- a/src/lib/components/Modal/ModalContent/ModalContentAoiModification.svelte
+++ b/src/lib/components/Modal/ModalContent/ModalContentAoiModification.svelte
@@ -1,17 +1,28 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
-  import type { ExtendedInterpretedDataType } from '$lib/type/Data/InterpretedData/ExtendedInterpretedDataType.ts'
-  import { getAois, getStimuli, updateMultipleAoi } from '$lib/stores/dataStore.ts'
-  import GeneralSelectBase from '$lib/components/General/GeneralSelect/GeneralSelectBase.svelte'
-  import GeneralButtonMinor from '$lib/components/General/GeneralButton/GeneralButtonMinor.svelte'
-  import { flip } from 'svelte/animate'
-  import GeneralRadio from '$lib/components/General/GeneralRadio/GeneralRadio.svelte'
   import GeneralButtonMajor from '$lib/components/General/GeneralButton/GeneralButtonMajor.svelte'
-  import { addErrorToast, addInfoToast, addSuccessToast } from '$lib/stores/toastStore.ts'
+  import GeneralButtonMinor from '$lib/components/General/GeneralButton/GeneralButtonMinor.svelte'
+  import GeneralRadio from '$lib/components/General/GeneralRadio/GeneralRadio.svelte'
+  import GeneralSelectBase from '$lib/components/General/GeneralSelect/GeneralSelectBase.svelte'
+  import {
+    getAois,
+    getStimuli,
+    updateMultipleAoi,
+  } from '$lib/stores/dataStore.ts'
+  import {
+    addErrorToast,
+    addInfoToast,
+    addSuccessToast,
+  } from '$lib/stores/toastStore.ts'
+  import type { ExtendedInterpretedDataType } from '$lib/type/Data/InterpretedData/ExtendedInterpretedDataType.ts'
+  import ArrowDown from 'lucide-svelte/icons/arrow-down'
+  import ArrowUp from 'lucide-svelte/icons/arrow-up'
+  import { onMount } from 'svelte'
+  import { flip } from 'svelte/animate'
 
   export let selectedStimulus = '0'
   export let userSelected = 'this'
-  let aoiObjects: ExtendedInterpretedDataType[] = [] /* Order in array is also important */
+  let aoiObjects: ExtendedInterpretedDataType[] =
+    [] /* Order in array is also important */
 
   $: {
     aoiObjects = getAois(parseInt(selectedStimulus))
@@ -20,10 +31,10 @@
   /**
    * TODO: Make reactive in the future (when stimuli can be updated)
    */
-  const stimuliOption = getStimuli().map((stimulus) => {
+  const stimuliOption = getStimuli().map(stimulus => {
     return {
       label: stimulus.displayedName,
-      value: stimulus.id.toString()
+      value: stimulus.id.toString(),
     }
   })
 
@@ -39,7 +50,7 @@
         ...aoiObjects.slice(0, index - 1),
         aoiObjects[index],
         aoiObjects[index - 1],
-        ...aoiObjects.slice(index + 1)
+        ...aoiObjects.slice(index + 1),
       ]
     }
   }
@@ -51,17 +62,26 @@
         ...aoiObjects.slice(0, index),
         aoiObjects[index + 1],
         aoiObjects[index],
-        ...aoiObjects.slice(index + 2)
+        ...aoiObjects.slice(index + 2),
       ]
     }
   }
 
   const handleSubmit = () => {
-    let handlerTypeForAoiStore: 'this_stimulus' | 'all_by_original_name' | 'all_by_displayed_name' = 'this_stimulus'
-    if (userSelected === 'all_original') handlerTypeForAoiStore = 'all_by_original_name'
-    if (userSelected === 'all_displayed') handlerTypeForAoiStore = 'all_by_displayed_name'
+    let handlerTypeForAoiStore:
+      | 'this_stimulus'
+      | 'all_by_original_name'
+      | 'all_by_displayed_name' = 'this_stimulus'
+    if (userSelected === 'all_original')
+      handlerTypeForAoiStore = 'all_by_original_name'
+    if (userSelected === 'all_displayed')
+      handlerTypeForAoiStore = 'all_by_displayed_name'
     try {
-      updateMultipleAoi(aoiObjects, parseInt(selectedStimulus), handlerTypeForAoiStore)
+      updateMultipleAoi(
+        aoiObjects,
+        parseInt(selectedStimulus),
+        handlerTypeForAoiStore
+      )
     } catch (e) {
       console.error(e)
       addErrorToast('Error while updating AOIs. See console for more details.')
@@ -71,104 +91,115 @@
       addInfoToast('Ordering of AOIs is not updated for other stimuli')
     }
   }
-
 </script>
 
 <div class="content">
-    <GeneralSelectBase
-        label="For stimulus"
-        options={stimuliOption}
-        bind:value={selectedStimulus}
-    />
+  <GeneralSelectBase
+    label="For stimulus"
+    options={stimuliOption}
+    bind:value={selectedStimulus}
+  />
 </div>
-{#if (aoiObjects.length === 0)}
-    <div>No AOIs found</div>
+{#if aoiObjects.length === 0}
+  <div>No AOIs found</div>
 {/if}
-{#if (aoiObjects.length > 0)}
-    <table class="grid content">
-        <thead>
-        <tr class='gr-line header'>
-            <th>Name</th>
-            <th>Displayed name</th>
-            <th>Color</th>
-            <th>Order</th>
+{#if aoiObjects.length > 0}
+  <table class="grid content">
+    <thead>
+      <tr class="gr-line header">
+        <th>Name</th>
+        <th>Displayed name</th>
+        <th>Color</th>
+        <th>Order</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each aoiObjects as aoi (aoi.id)}
+        <tr class="gr-line" animate:flip>
+          <td class="original-name">{aoi.originalName}</td>
+          <td>
+            <input
+              type="text"
+              id={aoi.id + 'displayedName'}
+              bind:value={aoi.displayedName}
+            />
+          </td>
+          <td>
+            <input type="color" id={aoi.id + 'color'} bind:value={aoi.color} />
+          </td>
+          <td>
+            <div class="button-group">
+              <GeneralButtonMinor
+                isDisabled={aoiObjects.indexOf(aoi) === 0}
+                on:click={() => handleObjectPositionUp(aoi)}
+              >
+                <ArrowUp size={'1em'} />
+              </GeneralButtonMinor>
+              <GeneralButtonMinor
+                isDisabled={aoiObjects.indexOf(aoi) === aoiObjects.length - 1}
+                on:click={() => handleObjectPositionDown(aoi)}
+              >
+                <ArrowDown size={'1em'} />
+              </GeneralButtonMinor>
+            </div>
+          </td>
         </tr>
-        </thead>
-        <tbody>
-        {#each aoiObjects as aoi (aoi.id)}
-            <tr class='gr-line' animate:flip>
-                <td class="original-name">{aoi.originalName}</td>
-                <td>
-                    <input type="text" id={aoi.id + 'displayedName'} bind:value={aoi.displayedName} />
-                </td>
-                <td>
-                    <input type="color" id={aoi.id + 'color'} bind:value={aoi.color} />
-                </td>
-                <td>
-                    <div class="button-group">
-                        <GeneralButtonMinor isDisabled={aoiObjects.indexOf(aoi) === 0} marginTop="0" on:click={() => handleObjectPositionUp(aoi)}>↑</GeneralButtonMinor>
-                        <GeneralButtonMinor isDisabled={aoiObjects.indexOf(aoi) === aoiObjects.length - 1} marginTop="0" on:click={() => handleObjectPositionDown(aoi)}>↓</GeneralButtonMinor>
-                    </div>
-                </td>
-            </tr>
-        {/each}
-        </tbody>
-    </table>
-    <div class="content">
-        <GeneralRadio
-                legend="Apply changes to"
-                options={[
-                  { label: 'This stimulus', value: 'this' },
-                  { label: 'All by original name', value: 'all_original' },
-                  { label: 'All by displayed name', value: 'all_displayed' }
-                ]}
-                bind:userSelected
-        />
-    </div>
-    <GeneralButtonMajor on:click={handleSubmit}>
-        Apply
-    </GeneralButtonMajor>
+      {/each}
+    </tbody>
+  </table>
+  <div class="content">
+    <GeneralRadio
+      legend="Apply changes to"
+      options={[
+        { label: 'This stimulus', value: 'this' },
+        { label: 'All by original name', value: 'all_original' },
+        { label: 'All by displayed name', value: 'all_displayed' },
+      ]}
+      bind:userSelected
+    />
+  </div>
+  <GeneralButtonMajor on:click={handleSubmit}>Apply</GeneralButtonMajor>
 {/if}
 
 <style>
-    /* Component Group */
-    input {
-        height: 34px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        margin: 0;
-        padding: 0.5rem;
-    }
+  /* Component Group */
+  input {
+    height: 34px;
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin: 0;
+    padding: 0.5rem;
+  }
 
-    input[type="color"] {
-        height: 34px;
-        width: 50px;
-        padding: 4px;
-        background: none;
-    }
+  input[type='color'] {
+    height: 34px;
+    width: 50px;
+    padding: 4px;
+    background: none;
+  }
 
-    .button-group {
-        display: flex;
-        gap: 5px;
-        flex-direction: row;
-    }
+  .button-group {
+    display: flex;
+    gap: 5px;
+    flex-direction: row;
+  }
 
-    th {
-        text-align: left;
-        font-size: 14px;
-    }
-    .original-name {
-        font-size: 14px;
-        padding-right: 10px;
-        color: #999;
-        cursor: not-allowed;
-    }
-    .content {
-        margin-bottom: 25px;
-    }
-    .original-name {
-        line-height: 1;
-        white-space: nowrap;
-    }
+  th {
+    text-align: left;
+    font-size: 14px;
+  }
+  .original-name {
+    font-size: 14px;
+    padding-right: 10px;
+    color: #999;
+    cursor: not-allowed;
+  }
+  .content {
+    margin-bottom: 25px;
+  }
+  .original-name {
+    line-height: 1;
+    white-space: nowrap;
+  }
 </style>

--- a/src/lib/components/Plot/ScarfPlot/ScarfPlot.svelte
+++ b/src/lib/components/Plot/ScarfPlot/ScarfPlot.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
   import { PlotAxisBreaks } from '$lib/class/Plot/PlotAxisBreaks/PlotAxisBreaks.ts'
-  import { ScarfPlotFillingFactoryS } from '$lib/class/Plot/ScarfPlot/ScarfPlotFillingFactoryS.ts'
   import { ScarfPlotAxisFactory } from '$lib/class/Plot/ScarfPlot/ScarfPlotAxisFactory.ts'
-  import ScarfPlotLegend from './ScarfPlotLegend/ScarfPlotLegend.svelte'
-  import { getParticipantOrderVector } from '$lib/stores/dataStore.ts'
+  import { ScarfPlotFillingFactoryS } from '$lib/class/Plot/ScarfPlot/ScarfPlotFillingFactoryS.ts'
   import PlotWrap from '$lib/components/Plot/PlotWrap.svelte'
-  import type { ScarfSettingsType } from '$lib/type/Settings/ScarfSettings/ScarfSettingsType.ts'
+  import { getParticipantOrderVector } from '$lib/stores/dataStore.ts'
+  import { scarfPlotStates } from '$lib/stores/scarfPlotsStore.ts'
   import type { ScarfFillingType } from '$lib/type/Filling/ScarfFilling/ScarfFillingType.ts'
   import type { ScarfTooltipFillingType } from '$lib/type/Filling/ScarfTooltipFilling/ScarfTooltipFillingType.ts'
-  import ScarfPlotTooltip from './ScarfPlotTooltip/ScarfPlotTooltip.svelte'
-  import ZoomInButton from './ScarfPlotButton/ScarfPlotButtonZoomIn.svelte'
-  import ZoomOutButton from './ScarfPlotButton/ScarfPlotButtonZoomOut.svelte'
-  import { scarfPlotStates } from '$lib/stores/scarfPlotsStore.ts'
-  import ScarfTimelineSelect from './ScarfPlotSelect/ScarfPlotSelectTimeline.svelte'
-  import ScarfPlotSelectGroup from './ScarfPlotSelect/ScarfPlotSelectGroup.svelte'
-  import ScarfPlotSelectStimulus from './ScarfPlotSelect/ScarfPlotSelectStimulus.svelte'
-  import ScarfPlotButtonMenu from './ScarfPlotButton/ScarfPlotButtonMenu.svelte'
+  import type { ScarfSettingsType } from '$lib/type/Settings/ScarfSettings/ScarfSettingsType.ts'
   import { onDestroy, onMount } from 'svelte'
+  import ScarfPlotHeader from './ScarfPlotHeader/ScarfPlotHeader.svelte'
+  import ScarfPlotLegend from './ScarfPlotLegend/ScarfPlotLegend.svelte'
+  import ScarfPlotTooltip from './ScarfPlotTooltip/ScarfPlotTooltip.svelte'
 
   export let scarfPlotId: number
   let tooltipArea: HTMLElement
@@ -262,14 +257,7 @@
 </script>
 
 <PlotWrap title="Scarf Plot">
-  <div class="nav" slot="header">
-    <ScarfPlotSelectStimulus scarfId={scarfPlotId} />
-    <ScarfTimelineSelect scarfId={scarfPlotId} />
-    <ScarfPlotSelectGroup scarfId={scarfPlotId} />
-    <ZoomInButton scarfId={scarfPlotId}></ZoomInButton>
-    <ZoomOutButton scarfId={scarfPlotId}></ZoomOutButton>
-    <ScarfPlotButtonMenu scarfId={scarfPlotId}></ScarfPlotButtonMenu>
-  </div>
+  <ScarfPlotHeader slot="header" scarfId={scarfPlotId} />
   <figure
     slot="body"
     class="tooltip-area js-mouseleave"

--- a/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonMenu.svelte
+++ b/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonMenu.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
   import MenuButton from '$lib/components/General/GeneralButton/GeneralButtonMenu.svelte'
-  import { modalStore } from '$lib/stores/modalStore.js'
   import ModalContentScarfPlotClip from '$lib/components/Modal/ModalContent/ModalContentScarfPlotClip.svelte'
+  import { modalStore } from '$lib/stores/modalStore.js'
   import {
     duplicateScarfPlotState,
     getScarfPlotState,
     removeScarfPlotState,
     scarfPlotStates,
   } from '$lib/stores/scarfPlotsStore.js'
-  import ModalContentDownloadScarfPlot from '../../../Modal/ModalContent/ModalContentDownloadScarfPlot.svelte'
+  import Copy from 'lucide-svelte/icons/copy'
+  import Download from 'lucide-svelte/icons/download'
+  import Scissors from 'lucide-svelte/icons/scissors-line-dashed'
+  import Settings from 'lucide-svelte/icons/settings-2'
+  import Trash from 'lucide-svelte/icons/trash'
+  import View from 'lucide-svelte/icons/view'
+  import type { ComponentProps } from 'svelte'
   import ModalContentAoiModification from '../../../Modal/ModalContent/ModalContentAoiModification.svelte'
   import ModalContentAoiVisibility from '../../../Modal/ModalContent/ModalContentAoiVisibility.svelte'
+  import ModalContentDownloadScarfPlot from '../../../Modal/ModalContent/ModalContentDownloadScarfPlot.svelte'
 
   export let scarfId: number
   let currentStimulusId: number
@@ -54,13 +61,17 @@
     duplicateScarfPlotState(scarfId)
   }
 
-  const items: { label: string; action: () => void }[] = [
-    { label: 'AOI customization', action: openAoiModificationModal },
-    { label: 'AOI visibility', action: openAoiVisibilityModal },
-    { label: 'Clip timeline', action: openClipModal },
-    { label: 'Download plot', action: downloadPlot },
-    { label: 'Duplicate scarf', action: duplicateScarf },
-    { label: 'Delete scarf', action: deleteScarf },
+  const items: ComponentProps<MenuButton>['items'] = [
+    {
+      label: 'AOI customization',
+      action: openAoiModificationModal,
+      icon: Settings,
+    },
+    { label: 'AOI visibility', action: openAoiVisibilityModal, icon: View },
+    { label: 'Clip timeline', action: openClipModal, icon: Scissors },
+    { label: 'Download plot', action: downloadPlot, icon: Download },
+    { label: 'Duplicate scarf', action: duplicateScarf, icon: Copy },
+    { label: 'Delete scarf', action: deleteScarf, icon: Trash },
   ]
 </script>
 

--- a/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonZoomIn.svelte
+++ b/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonZoomIn.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MinorButton from '$lib/components/General/GeneralButton/GeneralButtonMinor.svelte'
-  import { scarfPlotStates, updateZoom } from '$lib/stores/scarfPlotsStore.ts'
+  import { scarfPlotStates, updateZoom } from '$lib/stores/scarfPlotsStore.js'
+  import Plus from 'lucide-svelte/icons/plus'
   export let scarfId: number
 
   let zoom: number
@@ -18,4 +19,6 @@
   }
 </script>
 
-<MinorButton on:click={handleClick} {isDisabled}>+</MinorButton>
+<MinorButton on:click={handleClick} {isDisabled}>
+  <Plus size={'1em'} />
+</MinorButton>

--- a/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonZoomOut.svelte
+++ b/src/lib/components/Plot/ScarfPlot/ScarfPlotButton/ScarfPlotButtonZoomOut.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MinorButton from '$lib/components/General/GeneralButton/GeneralButtonMinor.svelte'
-  import { scarfPlotStates, updateZoom } from '$lib/stores/scarfPlotsStore.ts'
+  import { scarfPlotStates, updateZoom } from '$lib/stores/scarfPlotsStore.js'
+  import Minus from 'lucide-svelte/icons/minus'
   export let scarfId: number
 
   let zoom: number
@@ -19,14 +20,5 @@
 </script>
 
 <MinorButton on:click={handleClick} {isDisabled}>
-  <span>-</span>
+  <Minus size={'1em'} strokeWidth={1} />
 </MinorButton>
-
-<style>
-  span {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: -2px;
-  }
-</style>

--- a/src/lib/components/Plot/ScarfPlot/ScarfPlotHeader/ScarfPlotHeader.svelte
+++ b/src/lib/components/Plot/ScarfPlot/ScarfPlotHeader/ScarfPlotHeader.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import ZoomInButton from '../ScarfPlotButton/ScarfPlotButtonZoomIn.svelte'
+  import ZoomOutButton from '../ScarfPlotButton/ScarfPlotButtonZoomOut.svelte'
+  import ScarfPlotSelectStimulus from '../ScarfPlotSelect/ScarfPlotSelectStimulus.svelte'
+  import ScarfPlotButtonMenu from '../ScarfPlotButton/ScarfPlotButtonMenu.svelte'
+  import ScarfTimelineSelect from '../ScarfPlotSelect/ScarfPlotSelectTimeline.svelte'
+  import ScarfPlotSelectGroup from '../ScarfPlotSelect/ScarfPlotSelectGroup.svelte'
+
+  export let scarfId: number
+</script>
+
+<div class="nav">
+  <ScarfPlotSelectStimulus {scarfId} />
+  <ScarfTimelineSelect {scarfId} />
+  <ScarfPlotSelectGroup {scarfId} />
+  <ZoomInButton {scarfId} />
+  <ZoomOutButton {scarfId} />
+  <ScarfPlotButtonMenu {scarfId} />
+</div>
+
+<style>
+  .nav {
+    display: flex;
+    gap: 5px;
+    flex-wrap: wrap;
+  }
+</style>


### PR DESCRIPTION
This PR adds a icon library ([lucide](https://lucide.dev/guide/packages/lucide-svelte)) and uses icons in a few components related to the `ScarfPlot`.

## Future Work
- Not sure if this seems interesting/relevant for you @misavojte? The alignment of the icons should be improved. This is something I could looking into if you feel like using such a library makes sense.
- The markup of the select components should be improved  